### PR TITLE
Change to LevelType | Should fix Large Biome generation

### DIFF
--- a/logic/model/ServerSettings.cs
+++ b/logic/model/ServerSettings.cs
@@ -27,7 +27,7 @@ public class ServerSettings
     {
         Default,
         Flat,
-        Largebioms,
+        Large_biomes,
         Amplified,
         Buffet
     }


### PR DESCRIPTION
Request from Gordias on Discord [27/11/24]:

"I tried creating a new server but one of the world types is LargeBioms instead of LargeBiomes.  This causes the server to default to normal generation."

Adjusted to match: https://minecraft.fandom.com/wiki/Server.properties#level-type

