### PR TITLE
Paper & Waterfall API Link Update

### DIFF
--- a/logic/WebRequesters/PaperWebRequester.cs
+++ b/logic/WebRequesters/PaperWebRequester.cs
@@ -14,7 +14,7 @@ public class PaperWebRequester
 {
     public List<string> RequestPaperVersions()
     {
-        string url = "https://papermc.io/api/v2/projects/paper";
+        string url = "https://api.papermc.io/v2/projects/paper";
         string json = ResponseCache.Instance.UncacheResponse(url);
         if (json == null)
         {
@@ -51,7 +51,7 @@ public class PaperWebRequester
 
     public async Task<int> RequestLatestBuildId(string version)
     {
-        string url = "https://papermc.io/api/v2/projects/paper/versions/" + version;
+        string url = "https://api.papermc.io/v2/projects/paper/versions/" + version;
         {
             try
             {

--- a/logic/WebRequesters/WaterfallWebRequester.cs
+++ b/logic/WebRequesters/WaterfallWebRequester.cs
@@ -14,7 +14,7 @@ public class WaterfallWebRequester
 {
     public async Task<ServerVersion> RequestLatestWaterfallVersion()
     {
-        string url = "https://papermc.io/api/v2/projects/waterfall";
+        string url = "https://api.papermc.io/v2/projects/waterfall";
         string json = ResponseCache.Instance.UncacheResponse(url);
         if (json == null)
         {
@@ -53,7 +53,7 @@ public class WaterfallWebRequester
         waterfallVersion.JarLink = "https://thatstupidpaperremovedv1api.madebyitoncek.repl.co/api/v1/waterfall/" +
                                    waterfallVersions.versions[0] + "/latest/download";
         waterfallVersion.JarLink =
-            $"https://papermc.io/api/v2/projects/waterfall/versions/{version}/builds/{build}/downloads/waterfall-{version}-{build}.jar";
+            $"https://api.papermc.io/v2/projects/waterfall/versions/{version}/builds/{build}/downloads/waterfall-{version}-{build}.jar";
 
 
         return waterfallVersion;
@@ -61,7 +61,7 @@ public class WaterfallWebRequester
 
     private async Task<int> RequestLatestBuildId(string version)
     {
-        string url = "https://papermc.io/api/v2/projects/waterfall/versions/" + version;
+        string url = "https://api.papermc.io/v2/projects/waterfall/versions/" + version;
         {
             try
             {

--- a/logic/manager/WebRequestManager.cs
+++ b/logic/manager/WebRequestManager.cs
@@ -62,7 +62,7 @@ public sealed class WebRequestManager
             serverVersion.Version = version;
             int latestBuild = await paperWebRequester.RequestLatestBuildId(version);
             serverVersion.JarLink =
-                $"https://papermc.io/api/v2/projects/paper/versions/{version}/builds/{latestBuild}/downloads/paper-{version}-{latestBuild}.jar";
+                $"https://api.papermc.io/v2/projects/paper/versions/{version}/builds/{latestBuild}/downloads/paper-{version}-{latestBuild}.jar";
             versions.Add(serverVersion);
         }
 

--- a/logic/model/ServerSettings.cs
+++ b/logic/model/ServerSettings.cs
@@ -27,7 +27,7 @@ public class ServerSettings
     {
         Default,
         Flat,
-        Largebioms,
+        Large_biomes,
         Amplified,
         Buffet
     }


### PR DESCRIPTION
Updated https://papermc.io/api/v2/projects/ to https://api.papermc.io/v2/projects/ | Affects Paper & Waterfall downloads

Reported here: https://discord.com/channels/633632434336038912/1324074747377487965

Upon change no longer received a log stating the site was down and was able to download Paper & Waterfall .jars
Tested 1.21.4 / 1.21 / 1.12 & Waterfall